### PR TITLE
Add conversion to three letter codes and offical name

### DIFF
--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -3,6 +3,7 @@ import os
 import yaml
 import logging
 import Levenshtein
+from pycountry import countries
 from unicodedata import normalize, category
 
 log = logging.getLogger(__name__)
@@ -89,3 +90,39 @@ def to_code(country_name):
         log.info("Unknown country: %s (searched: %s)", country_name, name)
         COUNTRY_NAMES[name] = code
     return code
+
+
+def to_alpha_3(country_name):
+    """Given a human name for a country, return its ISO three-digit code"""
+    try:
+        return countries.get(alpha_2=to_code(country_name)).alpha_3
+    except LookupError:
+        return None
+
+
+def to_name(country_name):
+    """Given a human name for a country, return its short name"""
+    try:
+        return countries.get(alpha_2=to_code(country_name)).name
+    except LookupError:
+        return None
+
+
+def to_official_name(country_name):
+    """Given a human name for a country, return its full official name"""
+    try:
+        country = countries.get(alpha_2=to_code(country_name))
+        if hasattr(country, "official_name"):
+            return country.official_name
+        else:
+            return country.name
+    except LookupError:
+        return None
+
+
+def to_numeric(country_name):
+    """Given a human name for a country, return its numeric code as a string"""
+    try:
+        return countries.get(alpha_2=to_code(country_name)).numeric
+    except LookupError:
+        return None


### PR DESCRIPTION
Hi,

amazingly useful tool! Would you be open to add functionality to output three-letter codes and UN official names as well, e.g.

```python
assert("DEU" == countrynames.to_iso3_code("Deutschland"))
assert("Bolivia (Plurinational State of)" == countrynames.to_official_name("Bolivia"))
```

This quick attempt uses the Country-Codes data package as a source. It could of course be made more generic but this would cover all my use cases. Maybe short name would also be useful.