### PR TITLE
Add missing `__all__` exports and enable fuzzy matching for all converter functions

### DIFF
--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -13,7 +13,8 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__all__ = ['to_code']
+__all__ = ['to_code', 'to_alpha_3', 'to_name', 'to_official_name',
+           'to_numeric']
 
 COUNTRY_NAMES = {}
 
@@ -79,26 +80,27 @@ def to_code(country_name, fuzzy=True):
     return code
 
 
-def to_alpha_3(country_name):
+def to_alpha_3(country_name, fuzzy=True):
     """Given a human name for a country, return its ISO three-digit code"""
     try:
-        return countries.get(alpha_2=to_code(country_name)).alpha_3
+        return countries.get(alpha_2=to_code(country_name,
+                                             fuzzy=fuzzy)).alpha_3
     except LookupError:
         return None
 
 
-def to_name(country_name):
+def to_name(country_name, fuzzy=True):
     """Given a human name for a country, return its short name"""
     try:
-        return countries.get(alpha_2=to_code(country_name)).name
+        return countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy)).name
     except LookupError:
         return None
 
 
-def to_official_name(country_name):
+def to_official_name(country_name, fuzzy=True):
     """Given a human name for a country, return its full official name"""
     try:
-        country = countries.get(alpha_2=to_code(country_name))
+        country = countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy))
         if hasattr(country, "official_name"):
             return country.official_name
         else:
@@ -107,9 +109,10 @@ def to_official_name(country_name):
         return None
 
 
-def to_numeric(country_name):
+def to_numeric(country_name, fuzzy=True):
     """Given a human name for a country, return its numeric code as a string"""
     try:
-        return countries.get(alpha_2=to_code(country_name)).numeric
+        return countries.get(alpha_2=to_code(country_name,
+                                             fuzzy=fuzzy)).numeric
     except LookupError:
         return None

--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -51,7 +51,7 @@ def _fuzzy_search(name):
             return match
 
 
-def to_code(country_name, fuzzy=True):
+def to_code(country_name, fuzzy=False):
     """Given a human name for a country, return its ISO two-digit code."""
     # Lazy load country list
     if not len(COUNTRY_NAMES):
@@ -80,7 +80,7 @@ def to_code(country_name, fuzzy=True):
     return code
 
 
-def to_alpha_3(country_name, fuzzy=True):
+def to_alpha_3(country_name, fuzzy=False):
     """Given a human name for a country, return its ISO three-digit code"""
     try:
         return countries.get(alpha_2=to_code(country_name,
@@ -89,7 +89,7 @@ def to_alpha_3(country_name, fuzzy=True):
         return None
 
 
-def to_name(country_name, fuzzy=True):
+def to_name(country_name, fuzzy=False):
     """Given a human name for a country, return its short name"""
     try:
         return countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy)).name
@@ -97,7 +97,7 @@ def to_name(country_name, fuzzy=True):
         return None
 
 
-def to_official_name(country_name, fuzzy=True):
+def to_official_name(country_name, fuzzy=False):
     """Given a human name for a country, return its full official name"""
     try:
         country = countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy))
@@ -109,7 +109,7 @@ def to_official_name(country_name, fuzzy=True):
         return None
 
 
-def to_numeric(country_name, fuzzy=True):
+def to_numeric(country_name, fuzzy=False):
     """Given a human name for a country, return its numeric code as a string"""
     try:
         return countries.get(alpha_2=to_code(country_name,

--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -52,7 +52,11 @@ def _fuzzy_search(name):
 
 
 def to_code(country_name, fuzzy=False):
-    """Given a human name for a country, return its ISO two-digit code."""
+    """Given a human name for a country, return its ISO two-digit code.
+
+    Arguments:
+        ``fuzzy``: Try fuzzy matching based on Levenshtein distance.
+    """
     # Lazy load country list
     if not len(COUNTRY_NAMES):
         _load_data()
@@ -81,7 +85,11 @@ def to_code(country_name, fuzzy=False):
 
 
 def to_alpha_3(country_name, fuzzy=False):
-    """Given a human name for a country, return its ISO three-digit code"""
+    """Given a human name for a country, return its ISO three-digit code.
+
+    Arguments:
+        ``fuzzy``: Try fuzzy matching based on Levenshtein distance.
+    """
     try:
         return countries.get(alpha_2=to_code(country_name,
                                              fuzzy=fuzzy)).alpha_3
@@ -90,7 +98,11 @@ def to_alpha_3(country_name, fuzzy=False):
 
 
 def to_name(country_name, fuzzy=False):
-    """Given a human name for a country, return its short name"""
+    """Given a human name for a country, return its short name.
+
+    Arguments:
+        ``fuzzy``: Try fuzzy matching based on Levenshtein distance.
+    """
     try:
         return countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy)).name
     except LookupError:
@@ -98,7 +110,7 @@ def to_name(country_name, fuzzy=False):
 
 
 def to_official_name(country_name, fuzzy=False):
-    """Given a human name for a country, return its full official name"""
+    """Given a human name for a country, return its full official name."""
     try:
         country = countries.get(alpha_2=to_code(country_name, fuzzy=fuzzy))
         if hasattr(country, "official_name"):
@@ -110,7 +122,11 @@ def to_official_name(country_name, fuzzy=False):
 
 
 def to_numeric(country_name, fuzzy=False):
-    """Given a human name for a country, return its numeric code as a string"""
+    """Given a human name for a country, return its numeric code as a string.
+
+    Arguments:
+        ``fuzzy``: Try fuzzy matching based on Levenshtein distance.
+    """
     try:
         return countries.get(alpha_2=to_code(country_name,
                                              fuzzy=fuzzy)).numeric

--- a/test.py
+++ b/test.py
@@ -14,19 +14,19 @@ tests = [
 print("No fuzzy matching:")
 for test in tests:
     print([test,
-           countrynames.to_code(test, fuzzy=False),
-           countrynames.to_alpha_3(test, fuzzy=False),
-           countrynames.to_name(test, fuzzy=False),
-           countrynames.to_official_name(test, fuzzy=False),
-           countrynames.to_numeric(test, fuzzy=False)
-        ])
-
-print("With fuzzy matching:")
-for test in tests:
-    print([test,
            countrynames.to_code(test),
            countrynames.to_alpha_3(test),
            countrynames.to_name(test),
            countrynames.to_official_name(test),
            countrynames.to_numeric(test)
           ])
+
+print("With fuzzy matching:")
+for test in tests:
+    print([test,
+           countrynames.to_code(test, fuzzy=True),
+           countrynames.to_alpha_3(test, fuzzy=True),
+           countrynames.to_name(test, fuzzy=True),
+           countrynames.to_official_name(test, fuzzy=True),
+           countrynames.to_numeric(test, fuzzy=True)
+        ])

--- a/test.py
+++ b/test.py
@@ -11,6 +11,22 @@ tests = [
     None
 ]
 
+print("No fuzzy matching:")
 for test in tests:
-    print [test, countrynames.to_code(test, fuzzy=False),
-           countrynames.to_code(test)]
+    print([test,
+           countrynames.to_code(test, fuzzy=False),
+           countrynames.to_alpha_3(test, fuzzy=False),
+           countrynames.to_name(test, fuzzy=False),
+           countrynames.to_official_name(test, fuzzy=False),
+           countrynames.to_numeric(test, fuzzy=False)
+        ])
+
+print("With fuzzy matching:")
+for test in tests:
+    print([test,
+           countrynames.to_code(test),
+           countrynames.to_alpha_3(test),
+           countrynames.to_name(test),
+           countrynames.to_official_name(test),
+           countrynames.to_numeric(test)
+          ])


### PR DESCRIPTION
Also updates the test file to test the alternatives to
ISO-2 codes as well.

Test output looks like
```
No fuzzy matching:
['Germany', 'DE', 'DEU', 'Germany', 'Federal Republic of Germany', '276']
['DE', 'DE', 'DEU', 'Germany', 'Federal Republic of Germany', '276']
['UK', 'GB', 'GBR', 'United Kingdom', 'United Kingdom of Great Britain and Northern Ireland', '826']
['Российская Федерация', 'RU', 'RUS', 'Russian Federation', 'Russian Federation', '643']
['Rossiyskaya Federatsiya', None, None, None, None, None]
['Tgermany', None, None, None, None, None]
[None, None, None, None, None, None]
With fuzzy matching:
['Germany', 'DE', 'DEU', 'Germany', 'Federal Republic of Germany', '276']
['DE', 'DE', 'DEU', 'Germany', 'Federal Republic of Germany', '276']
['UK', 'GB', 'GBR', 'United Kingdom', 'United Kingdom of Great Britain and Northern Ireland', '826']
['Российская Федерация', 'RU', 'RUS', 'Russian Federation', 'Russian Federation', '643']
['Rossiyskaya Federatsiya', 'RU', 'RUS', 'Russian Federation', 'Russian Federation', '643']
['Tgermany', 'DE', 'DEU', 'Germany', 'Federal Republic of Germany', '276']
[None, None, None, None, None, None]

```