### PR TITLE
Add 3-digit non-standard country codes for EU and XK

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ assert 'DEU' == countrynames.to_alpha_3('Germany')
 assert '004' == countrynames.to_numeric('Afghanistan')
 ```
 
-## Non-standard countries
+## Non-standard country codes
 
-* ``XK`` - Kosovo
-* ``EU`` - European Union
+* ``XK`` or ``XKX`` - Kosovo
+* ``EU`` or ``EUU`` - European Union
 
 ## License
 

--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -91,8 +91,13 @@ def to_alpha_3(country_name, fuzzy=False):
         ``fuzzy``: Try fuzzy matching based on Levenshtein distance.
     """
     try:
-        return countries.get(alpha_2=to_code(country_name,
-                                             fuzzy=fuzzy)).alpha_3
+        code = to_code(country_name, fuzzy=fuzzy)
+        if code == "EU":  # European Union
+            return "EUU"
+        elif code == "XK":  # Kosovo
+            return "XKX"
+        else:
+            return countries.get(alpha_2=code).alpha_3
     except LookupError:
         return None
 

--- a/test.py
+++ b/test.py
@@ -8,6 +8,8 @@ tests = [
     u'Российская Федерация',
     'Rossiyskaya Federatsiya',
     'Tgermany',
+    'European Union',
+    'Kosovo',
     None
 ]
 


### PR DESCRIPTION
Thanks for the quick merge of #6, here's another tiny improvement:

This adds three-letter codes for the EU and Kosovo (XKX).

I'm using `EUU` as a three-letter code for the European Union, it's also used by the World Bank (http://databank.worldbank.org/data/reports.aspx?source=2&country=EUU)

Seems more long-term stable than using EU28 or similar ... not sure if you came across another option.

Also added them to the test script:

['European Union', 'EU', 'EUU', None, None, None]
['Kosovo', 'XK', 'XKX', None, None, None]
