### PR TITLE
Bugfixes and speedups to _fuzz_search()

### DIFF
--- a/countrynames/data.yaml
+++ b/countrynames/data.yaml
@@ -18078,7 +18078,7 @@ NL:
   - Nedàlân
   - Niderland
   - Hà Lan
-NO:
+"NO":
   - Норвегия
   - Orílẹ́ède Nọọwii
   - নরওয়ে

--- a/setup.py
+++ b/setup.py
@@ -3,46 +3,37 @@ from setuptools import setup, find_packages
 
 path = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(path, 'README.md'), "r") as f:
+with open(os.path.join(path, "README.md"), "r") as f:
     readme = f.read()
 
 setup(
-    name='countrynames',
-    version='1.6.1',
+    name="countrynames",
+    version="1.6.1",
     description="A library to map country names to ISO codes.",
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
     ],
-    keywords='names countries iso country',
-    author='Friedrich Lindenberg',
-    author_email='friedrich@pudo.org',
-    url='http://github.com/occrp/countrynames',
-    license='MIT',
-    packages=find_packages(exclude=['ez_setup', 'examples', 'test']),
+    keywords="names countries iso country",
+    author="Friedrich Lindenberg",
+    author_email="friedrich@pudo.org",
+    url="http://github.com/occrp/countrynames",
+    license="MIT",
+    packages=find_packages(exclude=["ez_setup", "examples", "test"]),
     namespace_packages=[],
-    package_data={
-        '': ['countrynames/data.yaml']
-    },
+    package_data={"": ["countrynames/data.yaml"]},
     include_package_data=True,
     zip_safe=False,
-    test_suite='nose.collector',
-    install_requires=[
-        'normality',
-        'python-Levenshtein',
-        'pyyaml',
-        'six'
-    ],
-    tests_require=[
-    ],
-    entry_points={
-    }
+    test_suite="nose.collector",
+    install_requires=["normality", "python-Levenshtein", "pyyaml", "pyicu", "six"],
+    tests_require=[],
+    entry_points={},
 )

--- a/test.py
+++ b/test.py
@@ -15,11 +15,11 @@ def test_to_code_3():
 
 
 def test_unicode():
-    assert to_code(u'Российская Федерация') == "RU"
+    assert to_code(u"Российская Федерация") == "RU"
 
 
 def test_fuzzy_matching():
-    assert to_code('Rossiyskaya Federatsiya', fuzzy=True) == "RU"
+    assert to_code("Rossiyskaya Federatsiya", fuzzy=True) == "RU"
     assert to_code("Falklands Islands", fuzzy=True) == "FK"
     assert to_code("TGermany", fuzzy=True) == "DE"
 
@@ -27,7 +27,7 @@ def test_fuzzy_matching():
 def test_non_standard_codes():
     assert to_code("European Union") == "EU"
     assert to_code_3("European Union") == "EUU"
-    assert to_code("Kosovo") == "XK"
+    assert to_code("Kosovo") == "XK", to_code("Kosovo")
     assert to_code_3("Kosovo") == "XKX"
 
 
@@ -36,8 +36,8 @@ def test_GB():
     assert to_code("Wales") == "GB-WLS"
     assert to_code("Northern Ireland") == "GB-NIR"
     assert to_code("Northern Ireland", fuzzy=True) == "GB-NIR"
-    assert to_code(
-        "United Kingdom of Great Britain and Northern Ireland") == "GB"
-    assert to_code(
-        "United Kingdom of Great Britain and Northern Ireland",
-        fuzzy=True) == "GB"
+    assert to_code("United Kingdom of Great Britain and Northern Ireland") == "GB"
+    assert (
+        to_code("United Kingdom of Great Britain and Northern Ireland", fuzzy=True)
+        == "GB"
+    )


### PR DESCRIPTION
There was a bug in `data.yml` that was preventing the data from being fully loaded. Apparently, YAML wants to turn the key literal "NO" into `False`. This was fixed be re-introducing quotes around the key.

Also, the `_fuzzy_search` method was optimized. It now runs at ~2x the speed simply by removing the second call to `Levenshtein.distance` and avoid using the `matches` list.

```
>>> # BEFORE:
>>> %timeit countrynames.to_code("Rossiyskaya Federatsiya", fuzzy=True)
44 ms ± 5.52 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
>>> # AFTER:
>>> %timeit countrynames.to_code("Rossiyskaya Federatsiya", fuzzy=True)
23.1 ms ± 631 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```