### PR TITLE
Add missing variant for Scotland

### DIFF
--- a/countrynames/data.yaml
+++ b/countrynames/data.yaml
@@ -183,6 +183,7 @@ GB-SCT:
   - Lothian
   - Linlithgowshire
   - Wigtownshire
+  - Escocia
 GB-NIR:
   - Northern Ireland
   - N Irish


### PR DESCRIPTION
Added Spanish name for Scotland ("Escocia")