### PR TITLE
improve performance with pickle dump/load of cached names

### DIFF
--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import Levenshtein  # type: ignore
+import _pickle as CPickle
+import os
 from functools import lru_cache
 from typing import Any, Optional, Dict
 
@@ -51,7 +53,12 @@ def to_code(
     """
     # Lazy load country list
     if not len(COUNTRY_NAMES):
-        COUNTRY_NAMES.update(_load_data())
+        try:
+            pickle_file = os.path.join(os.path.dirname(__file__), "data.pickle")
+            with open(pickle_file, "rb") as fh:
+                COUNTRY_NAMES.update(CPickle.load(fh))
+        except:
+            COUNTRY_NAMES.update(_load_data())
 
     # shortcut before costly ICU stuff
     if isinstance(country_name, str):

--- a/countrynames/compile.py
+++ b/countrynames/compile.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 import logging
+import _pickle as CPickle
 from typing import List, Dict, Set, Tuple
 from collections import defaultdict
 
@@ -18,6 +19,10 @@ def load_yaml_data() -> Dict[str, List[str]]:
             data[code].extend(names)
     return data
 
+def write_pickle(data: Dict[str, List[str]]) -> None:
+    pickle_file = os.path.join(CODE_DIR, "data.pickle")
+    with open(pickle_file, "wb") as fh:
+        CPickle.dump(data, fh)
 
 def write_python(data: Dict[str, List[str]]) -> None:
     python_file = os.path.join(CODE_DIR, "data.py")
@@ -48,3 +53,7 @@ if __name__ == "__main__":
     data = load_yaml_data()
     validate_data(data)
     write_python(data)
+    names = {}
+    for code, norm, _ in process_data(data):
+        names[norm] = code
+    write_pickle(names)


### PR DESCRIPTION
Adding a post-intall action seems impossible with pip installs and wheel packages (see https://stackoverflow.com/questions/24263774/post-install-script-after-installing-a-wheel).

This patch allows the user to manually compile a cached version of the names dictionnary using pickle. Loading performance is increased by a huge factor compared to the yaml file and even the py file.

Usage: python3 -m countrynames.compile

Note: python3 supported only