### PR TITLE
Use lru_cache for python 3.8 compatibility

### DIFF
--- a/countrynames/__init__.py
+++ b/countrynames/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import Levenshtein  # type: ignore
-from functools import cache
+from functools import lru_cache
 from typing import Any, Optional, Dict
 
 from countrynames.mappings import mappings
@@ -40,7 +40,7 @@ def _fuzzy_search(name: str) -> Optional[str]:
     return best_code
 
 
-@cache
+@lru_cache(maxsize=None)
 def to_code(
     country_name: Any, fuzzy: bool = False, default: Optional[str] = None
 ) -> Optional[str]:


### PR DESCRIPTION
`lru_cache(maxsize=None)` is equivalent to `cache` (ref: https://github.com/python/cpython/blob/affa9f22cfd1e83a5fb413e5ce2feef9ea1a49ac/Lib/functools.py#L653)

`cache` is available on Python 3.9+ only.