### PR TITLE
Add Netherlands variant

### DIFF
--- a/countrynames/data.yaml
+++ b/countrynames/data.yaml
@@ -18442,6 +18442,7 @@ NL:
   - 荷蘭
   - Sǝr ma kasǝŋ
   - Kingdom of the Netherlands
+  - Netherlands (Kingdom of the)
   - Nederlân
   - Nidɔlɛŋ
   - Yr Iseldiroedd


### PR DESCRIPTION
This adds `[Netherlands (Kingdom of the)`, which seems quite common in UN contexts.