### PR TITLE
Refuse to compile without PyICU

### DIFF
--- a/countrynames/compile.py
+++ b/countrynames/compile.py
@@ -45,6 +45,13 @@ def validate_data(data: Dict[str, List[str]]) -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
+    try:
+        # Explicitly test the import as it could be broken after OS upgrades. In that case
+        # a broken data.py will be generated, because normality has a fallback.
+        from icu import Transliterator  # type: ignore
+    except ImportError as e:
+        log.error("Loading PyICU failed: %r. Normalized names will be broken, refusing to compile.", e)
+        exit(1)
     data = load_yaml_data()
     validate_data(data)
     write_python(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 requires-python = ">= 3.10"
 dependencies = [
     "normality >= 2.5.0",
+    "pyicu",
     "pyyaml >= 5.0.0, < 7.0.0",
     "banal >= 1.0.6, < 1.1.0",
     "rapidfuzz >= 3.9.0, < 4.0.0",


### PR DESCRIPTION
Without it, we could (and did, if I'm not mistaken) release a broken data.py