### PR TITLE
Add three-letter code for Netherlands Antilles

### DIFF
--- a/countrynames/mappings.py
+++ b/countrynames/mappings.py
@@ -9,6 +9,7 @@ mappings = {
     "AI": "AIA",
     "AL": "ALB",
     "AM": "ARM",
+    "AN": "ANT",
     "AO": "AGO",
     "AQ": "ATA",
     "AR": "ARG",


### PR DESCRIPTION
This adds the mapping for the three-letter code for Netherlands Antilles.

They are dissolved but sometimes there is data which includes them. 

See https://databank.worldbank.org/metadataglossary/millennium-development-goals/country/ANT