### PR TITLE
Add Naoero to Nauru names

### DIFF
--- a/countrynames/data.yaml
+++ b/countrynames/data.yaml
@@ -19007,6 +19007,8 @@ NP:
   - Nepo
   - ⵏⵉⴱⴰⵍ
 NR:
+  - Naoero
+  - Republic of Naoero
   - Nauro
   - ナウル
   - 나우루


### PR DESCRIPTION
> On 26 June 2026, Nauru informed the United Nations that it had changed its name to Republic of Naoero.

https://www.un.org/en/about-us/member-states/naoero